### PR TITLE
📝 docs(skills): audit and humanize the four dev-workflow skills

### DIFF
--- a/.claude/skills/contributing/SKILL.md
+++ b/.claude/skills/contributing/SKILL.md
@@ -31,8 +31,6 @@ make build           # Build Go services (runs proto generation first)
 make test            # Run all tests
 ```
 
-If all tests pass, you're ready to contribute.
-
 ## Before Every PR
 
 Run these checks. They match what CI runs on GitHub Actions.
@@ -64,7 +62,7 @@ make test
 ```
 
 Runs Go tests, Python tests (excluding slow/eval), and web UI tests. Python
-tests run without real GCP credentials -- `conftest.py` mocks them.
+tests run without real GCP credentials; `conftest.py` mocks them.
 
 ### 4. Check coverage
 

--- a/.claude/skills/contributing/SKILL.md
+++ b/.claude/skills/contributing/SKILL.md
@@ -54,8 +54,8 @@ make lint
 Runs all linters:
 - `golangci-lint run ./...` (Go)
 - `uv run ruff check agents/` (Python)
-- `npx pyright agents/` (Python type checking)
-- Pre-commit hooks for YAML, JSON, Dockerfile validation
+- `npx --yes pyright@latest agents/` (Python type checking)
+- Pre-commit hooks for YAML and JSON syntax validation
 
 ### 3. Run tests
 
@@ -121,7 +121,7 @@ PRs are squash-merged. Write a clear PR title and description.
 | Command | What it runs | Needs infra? |
 |---|---|---|
 | `make test-go` | `go test ./... -count=1` | No (uses miniredis) |
-| `make test-py` | `pytest agents/ -x -q -m "not slow"` | No (mocks GCP) |
+| `make test-py` | `uv run pytest agents/ -x -q -m "not slow and not integration"` | No (mocks GCP) |
 | `make test-web` | `npm test` in admin-dash + tester | No |
 | `make eval` | Agent evaluations with real Gemini API | Yes (costs money) |
 | `make verify` | lint + unit tests + coverage | No |

--- a/.claude/skills/deploying/SKILL.md
+++ b/.claude/skills/deploying/SKILL.md
@@ -209,7 +209,7 @@ Every service should be "Ready". Cloud Run names use dashes:
 - `frontend`
 - `dash`
 - `runner-autopilot`
-- `runner-cloudrun`
+- `runner-cloudrun` (only if `enable_runner_cloudrun = true`)
 
 ### 2. Open the frontend
 
@@ -218,7 +218,8 @@ should load.
 
 ### 3. Open the admin dashboard
 
-The `admin-dash` service URL gets you the service health view.
+The `admin` Cloud Run service hosts the admin-dash UI; grab its URL for
+the service health view.
 
 ### 4. Verify Agent Engine agents
 

--- a/.claude/skills/deploying/SKILL.md
+++ b/.claude/skills/deploying/SKILL.md
@@ -12,7 +12,7 @@ description: >
 This skill walks through a cloud deploy of Race Condition to a GCP project:
 Terraform for the infra, Cloud Run and Agent Engine for the app, then a
 verification pass once it's up. The phases are gated. If a phase fails, stop
-and fix it — don't try to push past it.
+and fix it. Don't try to push past it.
 
 For local dev setup, use the `getting-started` skill instead.
 
@@ -44,7 +44,7 @@ gcloud auth login --update-adc
 ```
 
 Then set up Application Default Credentials separately (yes, this is a
-second login — gcloud and ADC use different token stores):
+second login; gcloud and ADC use different token stores):
 
 ```bash
 gcloud auth application-default login
@@ -107,7 +107,7 @@ developers = [
 ```
 
 Swap in the real project ID. Remind the developer to pick a strong
-`db_initial_password` and not commit the file — it should be gitignored.
+`db_initial_password` and not commit the file; it should be gitignored.
 
 HARD GATE: `infra/terraform.tfvars` must exist with the correct project ID
 before proceeding.
@@ -130,9 +130,8 @@ This downloads providers and initializes the Terraform backend.
 make infra-plan
 ```
 
-Show the plan output to the developer and get a clear yes before moving
-on. The plan lists every GCP resource that will be created (Cloud Run,
-Redis, VPC, NAT, etc.).
+Show the plan output to the developer. The plan lists every GCP resource
+that will be created (Cloud Run, Redis, VPC, NAT, etc.).
 
 HARD GATE: Explicit confirmation from the developer before applying.
 
@@ -272,7 +271,7 @@ bash agents/planner_with_memory/alloydb/deploy_alloydb.sh
 ```
 
 This creates the tables, installs pgvector, and loads the seed routes.
-Check the admin dashboard once it finishes — the planner-with-memory
+Check the admin dashboard once it finishes; the planner-with-memory
 agent should show as connected.
 
 ### GKE runner (if enabled)
@@ -294,7 +293,7 @@ Once the cluster is up:
 ### Monitoring (if enabled)
 
 Terraform creates the alert policies but doesn't wire up any notification
-channels — that part is on you:
+channels. That part is on you:
 
 1. Go to **Monitoring > Alerting** in the Cloud Console.
 2. Create a notification channel (email, Slack, PagerDuty, whatever).

--- a/.claude/skills/deploying/SKILL.md
+++ b/.claude/skills/deploying/SKILL.md
@@ -77,6 +77,7 @@ something, so explain the tradeoff before enabling it.
 |---|---|---|
 | AlloyDB | ~$200/mo | Route memory with vector embeddings (replaces Cloud SQL) |
 | GKE runner cluster | ~$300/mo | GPU-powered runner agents on Kubernetes |
+| Cloud Run runner | ~$0 idle, scales with load | LLM-powered runner agents on Cloud Run (alternative to GKE) |
 | Maps API key | Per-request pricing | Real map data for route planning (Maps, Places, Weather) |
 | Monitoring alerts | Free (alerting only) | Email alerts for Redis memory, NAT egress, etc. |
 
@@ -92,10 +93,12 @@ db_initial_password = "change-me-to-a-secure-password"
 region              = "us-central1"
 
 # Optional features
-enable_alloydb      = false
-enable_gke          = false
-enable_maps_api_key = false
-enable_monitoring   = false
+enable_alloydb         = false
+enable_gke             = false
+enable_runner_cloudrun = false
+enable_maps_api_key    = false
+enable_monitoring      = false
+alert_email            = ""  # required only when enable_monitoring = true
 
 # Developer access (optional)
 developers = [

--- a/.claude/skills/exploring-the-codebase/SKILL.md
+++ b/.claude/skills/exploring-the-codebase/SKILL.md
@@ -9,12 +9,9 @@ description: >
 # Exploring the Race Condition Codebase
 
 This is a multi-agent marathon simulation built for the Google Cloud Next '26
-Developer Keynote. The repo is also a reference architecture, so the layout
-is meant to be readable on its own.
-
-The fastest way to use this skill is to pick a question from "Where to start"
-below and follow the file pointers. Each pointer names a real file you can
-open.
+Developer Keynote. It also doubles as a reference architecture, so the
+layout is meant to be readable on its own. Pick a question from "Where
+to start" below and follow the file pointers.
 
 ## Where to start (by intent)
 
@@ -43,21 +40,18 @@ graph TD
 
 Four layers:
 
-- **Frontend** (`web/frontend/`) — Angular 21 + Three.js. 3D Las Vegas, runner
-  positions, weather, crowds. Talks to the gateway over WebSocket using
-  protobuf.
-- **Gateway** (`cmd/gateway/`, `internal/`) — Go service. Owns sessions,
-  routes A2A traffic, batches broadcasts.
-- **Agents** (`agents/`) — Python ADK. Planner variants, simulator variants,
-  runner variants. Each is its own process with its own port.
-- **Infrastructure** — Redis (sessions, pub-sub), Pub/Sub emulator
-  (telemetry), PostgreSQL with pgvector (route memory). Locally via
-  `docker-compose.yml`; in production via Memorystore, Pub/Sub, AlloyDB.
+- **Frontend** in `web/frontend/`. Angular 21 + Three.js renders the 3D
+  Las Vegas course, runner positions, weather, and crowds. Talks to the
+  gateway over WebSocket using protobuf.
+- **Gateway** in `cmd/gateway/` and `internal/`. Go service that owns
+  sessions, routes A2A traffic, and batches broadcasts.
+- **Agents** in `agents/`. Python ADK processes, one per agent variant,
+  each on its own port.
+- **Infrastructure**: Redis (sessions, pub-sub), Pub/Sub emulator
+  (telemetry), PostgreSQL + pgvector (route memory). Local via
+  `docker-compose.yml`; production via Memorystore, Pub/Sub, AlloyDB.
 
 ## Patterns worth understanding
-
-These are the design decisions you can pull out and reuse, with the *why* and
-the *where*.
 
 ### 1. Multiple agent variants instead of feature flags
 
@@ -81,10 +75,10 @@ what the LLM actually does in this codepath.
 The frontend can boot in **Cached** mode and replay NDJSON streams recorded
 from real agent runs. Live mode runs agents over WebSockets.
 
-Why: keynote demos cannot afford a network blip. The replay is timing-faithful
-to the real run, which means UI work, demo recording, and teaching can all
-happen with zero LLM cost. Anything that breaks under replay would have
-broken on stage, so the replay path doubles as an integration check.
+Why: keynote demos cannot afford a network blip. Replay is timing-faithful
+to the real run, so UI work and recording happen with zero LLM cost.
+Anything that breaks under replay would have broken on stage, which makes
+the replay path double as an integration check.
 
 Where: `web/frontend/src/app/components/DemoOverlay/demo.service.ts` (the
 `Ctrl+L` toggle and mode flash), `web/frontend/src/app/agent-gateway-updates.ts`
@@ -171,30 +165,24 @@ deliberate choice or relying on a temporary one.
 
 ## Code map
 
-```
-race-condition/
-├── agents/                     # Python AI agents (Google ADK)
-│   ├── planner*/               # Three planner variants (base, eval, memory)
-│   ├── simulator*/             # Race engine + fault-injection variant
-│   ├── runner*/                # LLM and deterministic runners
-│   └── utils/                  # Shared: A2A, session, telemetry, A2UI
-├── cmd/                        # Go service entry points
-│   └── gateway/                # The hub. Read main.go first.
-├── internal/                   # Go core
-│   ├── hub/                    # Session routing, broadcast batching
-│   ├── ecs/                    # Entity-Component-System
-│   ├── sim/                    # Simulation lifecycle
-│   ├── session/                # Redis + in-memory store
-│   └── agent/                  # A2A client + discovery
-├── web/                        # Frontends
-│   ├── frontend/               # Angular 21 + Three.js (the keynote UI)
-│   └── admin-dash, tester, agent-dash/  # Internal dashboards
-├── docs/                       # Architecture, guides, glossary
-├── infra/                      # Terraform for GCP deploy
-├── Dockerfile                  # Multi-stage; one stage per service
-├── docker-compose.yml          # Local Redis, Pub/Sub, PostgreSQL
-└── Procfile                    # Honcho process orchestration
-```
+- `agents/` — Python ADK agents. `planner*/` ships three variants (base,
+  eval, memory); `simulator*/` ships base plus a fault-injection variant;
+  `runner*/` ships LLM and deterministic versions. Shared helpers
+  (A2A, session, telemetry, A2UI) live in `agents/utils/`.
+- `cmd/` — Go service entry points: `gateway`, `admin`, `tester`,
+  `frontend`. Start at `cmd/gateway/main.go`.
+- `internal/` — Go core. `hub/` does session routing and broadcast
+  batching; `session/` stores state in Redis (with an in-memory
+  fallback); `agent/` is the gateway's A2A client and discovery; plus
+  `auth/`, `config/`, `middleware/`.
+- `web/` — Frontends. `web/frontend/` is the Angular 21 + Three.js
+  keynote UI; `web/admin-dash/`, `web/agent-dash/`, and `web/tester/`
+  are internal dashboards.
+- `docs/` — Architecture, guides, glossary.
+- `infra/` — Terraform for GCP deployment.
+- `Dockerfile`, `docker-compose.yml`, `Procfile` — multi-stage container
+  build, local infra (Redis / Pub/Sub / PostgreSQL), and Honcho process
+  orchestration for `make start`.
 
 ## Documentation map
 

--- a/.claude/skills/exploring-the-codebase/SKILL.md
+++ b/.claude/skills/exploring-the-codebase/SKILL.md
@@ -24,7 +24,7 @@ to start" below and follow the file pointers.
 | How the planner builds routes | `docs/architecture/route_planning.md` → `agents/planner/agent.py` → `agents/planner/prompts.py` |
 | The cached/replay reliability system | `web/frontend/src/app/components/DemoOverlay/demo.service.ts` → `agent-gateway-updates.ts` → the `.ndjson` recordings under `web/frontend/public/assets/` |
 | Backend-driven UI (A2UI) | `docs/architecture/a2ui_protocol.md` → `agents/utils/` (search for `a2ui`) → frontend `a2-ui-controller.component.ts` |
-| The deterministic runner baseline | `agents/runner/agent.py` (shared mechanics) → `agents/runner_autopilot/agent.py` (overrides) |
+| How the runner pair is structured | `agents/runner/agent.py` (LLM runner; shared mechanics) → `agents/runner_autopilot/agent.py` (deterministic override of the decision callback) |
 | Deployment and infra | `infra/README.md` → `infra/` (Terraform modules) → `Dockerfile` |
 | Tests and how they run offline | `docs/guides/testing.md` → root `conftest.py` |
 

--- a/.claude/skills/exploring-the-codebase/SKILL.md
+++ b/.claude/skills/exploring-the-codebase/SKILL.md
@@ -23,12 +23,12 @@ open.
 | The whole system end-to-end | `docs/architecture/system_architecture.md` → `cmd/gateway/main.go` → one agent's `agent.py` |
 | How agents discover and talk to each other | `docs/guides/a2a-implementation-guide.md` → `internal/agent/` → any `agent.json` in `agents/*/` |
 | The Hub and session routing | `docs/architecture/multi_session_routing.md` → `internal/hub/` → `internal/session/` |
-| The simulator's tick loop | `agents/simulator/agent.py` → `agents/simulator/simulation/engine.py` → `tick_callback.py` |
+| The simulator's tick loop | `agents/simulator/agent.py` (`race_engine = LoopAgent(...)`) → `tick_callback.py` → `broadcast.py` → `collector.py` |
 | How the planner builds routes | `docs/architecture/route_planning.md` → `agents/planner/agent.py` → `agents/planner/prompts.py` |
 | The cached/replay reliability system | `web/frontend/src/app/components/DemoOverlay/demo.service.ts` → `agent-gateway-updates.ts` → the `.ndjson` recordings under `web/frontend/public/assets/` |
-| Backend-driven UI (A2UI) | `docs/architecture/a2ui_protocol.md` → `agents/utils/` (search for `a2ui`) → frontend `a2-ui-controller.ts` |
+| Backend-driven UI (A2UI) | `docs/architecture/a2ui_protocol.md` → `agents/utils/` (search for `a2ui`) → frontend `a2-ui-controller.component.ts` |
 | The deterministic runner baseline | `agents/runner/agent.py` (shared mechanics) → `agents/runner_autopilot/agent.py` (overrides) |
-| Deployment and infra | `docs/gcp-deployment.md` → `infra/` (Terraform) → `Dockerfile` |
+| Deployment and infra | `infra/README.md` → `infra/` (Terraform modules) → `Dockerfile` |
 | Tests and how they run offline | `docs/guides/testing.md` → root `conftest.py` |
 
 ## High-level topology
@@ -107,20 +107,7 @@ Where: `internal/hub/` (broadcast and fanout), `internal/session/` (Redis +
 in-memory fallback), `docs/architecture/multi_session_routing.md` for the
 rationale and the failure modes it prevents.
 
-### 4. ECS for simulation state
-
-`internal/ecs/` implements an Entity-Component-System pattern: entities have
-opaque IDs, components carry data, systems update them.
-
-Why: the gateway routes simulation state without knowing what any specific
-agent type means. Adding a new agent that emits a new component type does
-not require gateway changes. Broadcast batching works for the same reason:
-components can be diffed and merged without parsing agent-specific payloads.
-
-Where: `internal/ecs/` (the implementation), `internal/sim/` (lifecycle
-that uses it).
-
-### 5. Tick-based simulator as an ADK pipeline
+### 4. Tick-based simulator as an ADK pipeline
 
 The simulator is a `SequentialAgent` of three stages:
 `PreRace → LoopAgent (≤200 ticks) → PostRace`. Each tick advances the clock,
@@ -130,12 +117,12 @@ Why: ADK's `LoopAgent` gives a clean termination contract and lets each tick
 emit telemetry events that the dashboard can group by `invocation_id`. The
 simulator stays pure-ADK code rather than a bespoke loop.
 
-Where: `agents/simulator/agent.py` (pipeline definition),
-`agents/simulator/simulation/engine.py` (the loop body),
-`tick_callback.py` and `broadcast.py` (per-tick fan-out),
-`collector.py` (decision aggregation).
+Where: `agents/simulator/agent.py` (pipeline definition and the
+`race_engine` LoopAgent itself), `tick_callback.py` (per-tick body),
+`broadcast.py` (fan-out to runners), `collector.py` (decision
+aggregation).
 
-### 6. A2UI for backend-driven UI
+### 5. A2UI for backend-driven UI
 
 Agents emit UI primitives (cards, route lists, action buttons) over the wire
 as declarative JSON. The frontend renders them generically.
@@ -146,10 +133,10 @@ agents own their own UI surfaces and the frontend stays a renderer.
 
 Where: `docs/architecture/a2ui_protocol.md` for the spec,
 `agents/utils/` (search for `a2ui`) for the agent-side helpers,
-`web/frontend/src/app/components/a2ui/a2-ui-controller.ts` for the renderer.
+`web/frontend/src/app/components/a2ui/a2-ui-controller.component.ts` for the renderer.
 The Sandbox demo's "top 3 routes" panel is the easiest example to read end-to-end.
 
-### 7. A2A for agent-to-agent communication
+### 6. A2A for agent-to-agent communication
 
 Agents discover each other via cards at `/.well-known/agent-card.json`. The
 gateway fetches them at startup and routes by declared skill.
@@ -181,9 +168,6 @@ deliberate choice or relying on a temporary one.
   bill. Use it whenever you do not specifically need LLM behavior.
 - **Maps API key is optional.** Without `GOOGLE_MAPS_API_KEY` the planner
   falls back to plan-only routes. This is deliberate degradation, not a bug.
-- **`docs/plans/` contains historical implementation plans.** They are not
-  current architecture: read `docs/architecture/` for "how it is" and
-  `docs/plans/` for "how we got there."
 
 ## Code map
 

--- a/.claude/skills/getting-started/SKILL.md
+++ b/.claude/skills/getting-started/SKILL.md
@@ -108,8 +108,8 @@ The Planner works without a Maps key but produces better routes with one.
 1. Enable APIs:
    ```bash
    gcloud services enable apikeys.googleapis.com \
-     agentregistry.googleapis.com mapstools.googleapis.com \
-     places.googleapis.com weather.googleapis.com
+     agentregistry.googleapis.com cloudapiregistry.googleapis.com \
+     mapstools.googleapis.com places.googleapis.com weather.googleapis.com
    ```
 
 2. Create a key at https://console.cloud.google.com/apis/credentials.

--- a/.gemini/skills/contributing/SKILL.md
+++ b/.gemini/skills/contributing/SKILL.md
@@ -31,8 +31,6 @@ make build           # Build Go services (runs proto generation first)
 make test            # Run all tests
 ```
 
-If all tests pass, you're ready to contribute.
-
 ## Before Every PR
 
 Run these checks. They match what CI runs on GitHub Actions.
@@ -64,7 +62,7 @@ make test
 ```
 
 Runs Go tests, Python tests (excluding slow/eval), and web UI tests. Python
-tests run without real GCP credentials -- `conftest.py` mocks them.
+tests run without real GCP credentials; `conftest.py` mocks them.
 
 ### 4. Check coverage
 

--- a/.gemini/skills/contributing/SKILL.md
+++ b/.gemini/skills/contributing/SKILL.md
@@ -54,8 +54,8 @@ make lint
 Runs all linters:
 - `golangci-lint run ./...` (Go)
 - `uv run ruff check agents/` (Python)
-- `npx pyright agents/` (Python type checking)
-- Pre-commit hooks for YAML, JSON, Dockerfile validation
+- `npx --yes pyright@latest agents/` (Python type checking)
+- Pre-commit hooks for YAML and JSON syntax validation
 
 ### 3. Run tests
 
@@ -121,7 +121,7 @@ PRs are squash-merged. Write a clear PR title and description.
 | Command | What it runs | Needs infra? |
 |---|---|---|
 | `make test-go` | `go test ./... -count=1` | No (uses miniredis) |
-| `make test-py` | `pytest agents/ -x -q -m "not slow"` | No (mocks GCP) |
+| `make test-py` | `uv run pytest agents/ -x -q -m "not slow and not integration"` | No (mocks GCP) |
 | `make test-web` | `npm test` in admin-dash + tester | No |
 | `make eval` | Agent evaluations with real Gemini API | Yes (costs money) |
 | `make verify` | lint + unit tests + coverage | No |

--- a/.gemini/skills/deploying/SKILL.md
+++ b/.gemini/skills/deploying/SKILL.md
@@ -209,7 +209,7 @@ Every service should be "Ready". Cloud Run names use dashes:
 - `frontend`
 - `dash`
 - `runner-autopilot`
-- `runner-cloudrun`
+- `runner-cloudrun` (only if `enable_runner_cloudrun = true`)
 
 ### 2. Open the frontend
 
@@ -218,7 +218,8 @@ should load.
 
 ### 3. Open the admin dashboard
 
-The `admin-dash` service URL gets you the service health view.
+The `admin` Cloud Run service hosts the admin-dash UI; grab its URL for
+the service health view.
 
 ### 4. Verify Agent Engine agents
 

--- a/.gemini/skills/deploying/SKILL.md
+++ b/.gemini/skills/deploying/SKILL.md
@@ -12,7 +12,7 @@ description: >
 This skill walks through a cloud deploy of Race Condition to a GCP project:
 Terraform for the infra, Cloud Run and Agent Engine for the app, then a
 verification pass once it's up. The phases are gated. If a phase fails, stop
-and fix it — don't try to push past it.
+and fix it. Don't try to push past it.
 
 For local dev setup, use the `getting-started` skill instead.
 
@@ -44,7 +44,7 @@ gcloud auth login --update-adc
 ```
 
 Then set up Application Default Credentials separately (yes, this is a
-second login — gcloud and ADC use different token stores):
+second login; gcloud and ADC use different token stores):
 
 ```bash
 gcloud auth application-default login
@@ -107,7 +107,7 @@ developers = [
 ```
 
 Swap in the real project ID. Remind the developer to pick a strong
-`db_initial_password` and not commit the file — it should be gitignored.
+`db_initial_password` and not commit the file; it should be gitignored.
 
 HARD GATE: `infra/terraform.tfvars` must exist with the correct project ID
 before proceeding.
@@ -130,9 +130,8 @@ This downloads providers and initializes the Terraform backend.
 make infra-plan
 ```
 
-Show the plan output to the developer and get a clear yes before moving
-on. The plan lists every GCP resource that will be created (Cloud Run,
-Redis, VPC, NAT, etc.).
+Show the plan output to the developer. The plan lists every GCP resource
+that will be created (Cloud Run, Redis, VPC, NAT, etc.).
 
 HARD GATE: Explicit confirmation from the developer before applying.
 
@@ -272,7 +271,7 @@ bash agents/planner_with_memory/alloydb/deploy_alloydb.sh
 ```
 
 This creates the tables, installs pgvector, and loads the seed routes.
-Check the admin dashboard once it finishes — the planner-with-memory
+Check the admin dashboard once it finishes; the planner-with-memory
 agent should show as connected.
 
 ### GKE runner (if enabled)
@@ -294,7 +293,7 @@ Once the cluster is up:
 ### Monitoring (if enabled)
 
 Terraform creates the alert policies but doesn't wire up any notification
-channels — that part is on you:
+channels. That part is on you:
 
 1. Go to **Monitoring > Alerting** in the Cloud Console.
 2. Create a notification channel (email, Slack, PagerDuty, whatever).

--- a/.gemini/skills/deploying/SKILL.md
+++ b/.gemini/skills/deploying/SKILL.md
@@ -77,6 +77,7 @@ something, so explain the tradeoff before enabling it.
 |---|---|---|
 | AlloyDB | ~$200/mo | Route memory with vector embeddings (replaces Cloud SQL) |
 | GKE runner cluster | ~$300/mo | GPU-powered runner agents on Kubernetes |
+| Cloud Run runner | ~$0 idle, scales with load | LLM-powered runner agents on Cloud Run (alternative to GKE) |
 | Maps API key | Per-request pricing | Real map data for route planning (Maps, Places, Weather) |
 | Monitoring alerts | Free (alerting only) | Email alerts for Redis memory, NAT egress, etc. |
 
@@ -92,10 +93,12 @@ db_initial_password = "change-me-to-a-secure-password"
 region              = "us-central1"
 
 # Optional features
-enable_alloydb      = false
-enable_gke          = false
-enable_maps_api_key = false
-enable_monitoring   = false
+enable_alloydb         = false
+enable_gke             = false
+enable_runner_cloudrun = false
+enable_maps_api_key    = false
+enable_monitoring      = false
+alert_email            = ""  # required only when enable_monitoring = true
 
 # Developer access (optional)
 developers = [

--- a/.gemini/skills/exploring-the-codebase/SKILL.md
+++ b/.gemini/skills/exploring-the-codebase/SKILL.md
@@ -9,12 +9,9 @@ description: >
 # Exploring the Race Condition Codebase
 
 This is a multi-agent marathon simulation built for the Google Cloud Next '26
-Developer Keynote. The repo is also a reference architecture, so the layout
-is meant to be readable on its own.
-
-The fastest way to use this skill is to pick a question from "Where to start"
-below and follow the file pointers. Each pointer names a real file you can
-open.
+Developer Keynote. It also doubles as a reference architecture, so the
+layout is meant to be readable on its own. Pick a question from "Where
+to start" below and follow the file pointers.
 
 ## Where to start (by intent)
 
@@ -43,21 +40,18 @@ graph TD
 
 Four layers:
 
-- **Frontend** (`web/frontend/`) — Angular 21 + Three.js. 3D Las Vegas, runner
-  positions, weather, crowds. Talks to the gateway over WebSocket using
-  protobuf.
-- **Gateway** (`cmd/gateway/`, `internal/`) — Go service. Owns sessions,
-  routes A2A traffic, batches broadcasts.
-- **Agents** (`agents/`) — Python ADK. Planner variants, simulator variants,
-  runner variants. Each is its own process with its own port.
-- **Infrastructure** — Redis (sessions, pub-sub), Pub/Sub emulator
-  (telemetry), PostgreSQL with pgvector (route memory). Locally via
-  `docker-compose.yml`; in production via Memorystore, Pub/Sub, AlloyDB.
+- **Frontend** in `web/frontend/`. Angular 21 + Three.js renders the 3D
+  Las Vegas course, runner positions, weather, and crowds. Talks to the
+  gateway over WebSocket using protobuf.
+- **Gateway** in `cmd/gateway/` and `internal/`. Go service that owns
+  sessions, routes A2A traffic, and batches broadcasts.
+- **Agents** in `agents/`. Python ADK processes, one per agent variant,
+  each on its own port.
+- **Infrastructure**: Redis (sessions, pub-sub), Pub/Sub emulator
+  (telemetry), PostgreSQL + pgvector (route memory). Local via
+  `docker-compose.yml`; production via Memorystore, Pub/Sub, AlloyDB.
 
 ## Patterns worth understanding
-
-These are the design decisions you can pull out and reuse, with the *why* and
-the *where*.
 
 ### 1. Multiple agent variants instead of feature flags
 
@@ -81,10 +75,10 @@ what the LLM actually does in this codepath.
 The frontend can boot in **Cached** mode and replay NDJSON streams recorded
 from real agent runs. Live mode runs agents over WebSockets.
 
-Why: keynote demos cannot afford a network blip. The replay is timing-faithful
-to the real run, which means UI work, demo recording, and teaching can all
-happen with zero LLM cost. Anything that breaks under replay would have
-broken on stage, so the replay path doubles as an integration check.
+Why: keynote demos cannot afford a network blip. Replay is timing-faithful
+to the real run, so UI work and recording happen with zero LLM cost.
+Anything that breaks under replay would have broken on stage, which makes
+the replay path double as an integration check.
 
 Where: `web/frontend/src/app/components/DemoOverlay/demo.service.ts` (the
 `Ctrl+L` toggle and mode flash), `web/frontend/src/app/agent-gateway-updates.ts`
@@ -171,30 +165,24 @@ deliberate choice or relying on a temporary one.
 
 ## Code map
 
-```
-race-condition/
-├── agents/                     # Python AI agents (Google ADK)
-│   ├── planner*/               # Three planner variants (base, eval, memory)
-│   ├── simulator*/             # Race engine + fault-injection variant
-│   ├── runner*/                # LLM and deterministic runners
-│   └── utils/                  # Shared: A2A, session, telemetry, A2UI
-├── cmd/                        # Go service entry points
-│   └── gateway/                # The hub. Read main.go first.
-├── internal/                   # Go core
-│   ├── hub/                    # Session routing, broadcast batching
-│   ├── ecs/                    # Entity-Component-System
-│   ├── sim/                    # Simulation lifecycle
-│   ├── session/                # Redis + in-memory store
-│   └── agent/                  # A2A client + discovery
-├── web/                        # Frontends
-│   ├── frontend/               # Angular 21 + Three.js (the keynote UI)
-│   └── admin-dash, tester, agent-dash/  # Internal dashboards
-├── docs/                       # Architecture, guides, glossary
-├── infra/                      # Terraform for GCP deploy
-├── Dockerfile                  # Multi-stage; one stage per service
-├── docker-compose.yml          # Local Redis, Pub/Sub, PostgreSQL
-└── Procfile                    # Honcho process orchestration
-```
+- `agents/` — Python ADK agents. `planner*/` ships three variants (base,
+  eval, memory); `simulator*/` ships base plus a fault-injection variant;
+  `runner*/` ships LLM and deterministic versions. Shared helpers
+  (A2A, session, telemetry, A2UI) live in `agents/utils/`.
+- `cmd/` — Go service entry points: `gateway`, `admin`, `tester`,
+  `frontend`. Start at `cmd/gateway/main.go`.
+- `internal/` — Go core. `hub/` does session routing and broadcast
+  batching; `session/` stores state in Redis (with an in-memory
+  fallback); `agent/` is the gateway's A2A client and discovery; plus
+  `auth/`, `config/`, `middleware/`.
+- `web/` — Frontends. `web/frontend/` is the Angular 21 + Three.js
+  keynote UI; `web/admin-dash/`, `web/agent-dash/`, and `web/tester/`
+  are internal dashboards.
+- `docs/` — Architecture, guides, glossary.
+- `infra/` — Terraform for GCP deployment.
+- `Dockerfile`, `docker-compose.yml`, `Procfile` — multi-stage container
+  build, local infra (Redis / Pub/Sub / PostgreSQL), and Honcho process
+  orchestration for `make start`.
 
 ## Documentation map
 

--- a/.gemini/skills/exploring-the-codebase/SKILL.md
+++ b/.gemini/skills/exploring-the-codebase/SKILL.md
@@ -24,7 +24,7 @@ to start" below and follow the file pointers.
 | How the planner builds routes | `docs/architecture/route_planning.md` → `agents/planner/agent.py` → `agents/planner/prompts.py` |
 | The cached/replay reliability system | `web/frontend/src/app/components/DemoOverlay/demo.service.ts` → `agent-gateway-updates.ts` → the `.ndjson` recordings under `web/frontend/public/assets/` |
 | Backend-driven UI (A2UI) | `docs/architecture/a2ui_protocol.md` → `agents/utils/` (search for `a2ui`) → frontend `a2-ui-controller.component.ts` |
-| The deterministic runner baseline | `agents/runner/agent.py` (shared mechanics) → `agents/runner_autopilot/agent.py` (overrides) |
+| How the runner pair is structured | `agents/runner/agent.py` (LLM runner; shared mechanics) → `agents/runner_autopilot/agent.py` (deterministic override of the decision callback) |
 | Deployment and infra | `infra/README.md` → `infra/` (Terraform modules) → `Dockerfile` |
 | Tests and how they run offline | `docs/guides/testing.md` → root `conftest.py` |
 

--- a/.gemini/skills/exploring-the-codebase/SKILL.md
+++ b/.gemini/skills/exploring-the-codebase/SKILL.md
@@ -23,12 +23,12 @@ open.
 | The whole system end-to-end | `docs/architecture/system_architecture.md` → `cmd/gateway/main.go` → one agent's `agent.py` |
 | How agents discover and talk to each other | `docs/guides/a2a-implementation-guide.md` → `internal/agent/` → any `agent.json` in `agents/*/` |
 | The Hub and session routing | `docs/architecture/multi_session_routing.md` → `internal/hub/` → `internal/session/` |
-| The simulator's tick loop | `agents/simulator/agent.py` → `agents/simulator/simulation/engine.py` → `tick_callback.py` |
+| The simulator's tick loop | `agents/simulator/agent.py` (`race_engine = LoopAgent(...)`) → `tick_callback.py` → `broadcast.py` → `collector.py` |
 | How the planner builds routes | `docs/architecture/route_planning.md` → `agents/planner/agent.py` → `agents/planner/prompts.py` |
 | The cached/replay reliability system | `web/frontend/src/app/components/DemoOverlay/demo.service.ts` → `agent-gateway-updates.ts` → the `.ndjson` recordings under `web/frontend/public/assets/` |
-| Backend-driven UI (A2UI) | `docs/architecture/a2ui_protocol.md` → `agents/utils/` (search for `a2ui`) → frontend `a2-ui-controller.ts` |
+| Backend-driven UI (A2UI) | `docs/architecture/a2ui_protocol.md` → `agents/utils/` (search for `a2ui`) → frontend `a2-ui-controller.component.ts` |
 | The deterministic runner baseline | `agents/runner/agent.py` (shared mechanics) → `agents/runner_autopilot/agent.py` (overrides) |
-| Deployment and infra | `docs/gcp-deployment.md` → `infra/` (Terraform) → `Dockerfile` |
+| Deployment and infra | `infra/README.md` → `infra/` (Terraform modules) → `Dockerfile` |
 | Tests and how they run offline | `docs/guides/testing.md` → root `conftest.py` |
 
 ## High-level topology
@@ -107,20 +107,7 @@ Where: `internal/hub/` (broadcast and fanout), `internal/session/` (Redis +
 in-memory fallback), `docs/architecture/multi_session_routing.md` for the
 rationale and the failure modes it prevents.
 
-### 4. ECS for simulation state
-
-`internal/ecs/` implements an Entity-Component-System pattern: entities have
-opaque IDs, components carry data, systems update them.
-
-Why: the gateway routes simulation state without knowing what any specific
-agent type means. Adding a new agent that emits a new component type does
-not require gateway changes. Broadcast batching works for the same reason:
-components can be diffed and merged without parsing agent-specific payloads.
-
-Where: `internal/ecs/` (the implementation), `internal/sim/` (lifecycle
-that uses it).
-
-### 5. Tick-based simulator as an ADK pipeline
+### 4. Tick-based simulator as an ADK pipeline
 
 The simulator is a `SequentialAgent` of three stages:
 `PreRace → LoopAgent (≤200 ticks) → PostRace`. Each tick advances the clock,
@@ -130,12 +117,12 @@ Why: ADK's `LoopAgent` gives a clean termination contract and lets each tick
 emit telemetry events that the dashboard can group by `invocation_id`. The
 simulator stays pure-ADK code rather than a bespoke loop.
 
-Where: `agents/simulator/agent.py` (pipeline definition),
-`agents/simulator/simulation/engine.py` (the loop body),
-`tick_callback.py` and `broadcast.py` (per-tick fan-out),
-`collector.py` (decision aggregation).
+Where: `agents/simulator/agent.py` (pipeline definition and the
+`race_engine` LoopAgent itself), `tick_callback.py` (per-tick body),
+`broadcast.py` (fan-out to runners), `collector.py` (decision
+aggregation).
 
-### 6. A2UI for backend-driven UI
+### 5. A2UI for backend-driven UI
 
 Agents emit UI primitives (cards, route lists, action buttons) over the wire
 as declarative JSON. The frontend renders them generically.
@@ -146,10 +133,10 @@ agents own their own UI surfaces and the frontend stays a renderer.
 
 Where: `docs/architecture/a2ui_protocol.md` for the spec,
 `agents/utils/` (search for `a2ui`) for the agent-side helpers,
-`web/frontend/src/app/components/a2ui/a2-ui-controller.ts` for the renderer.
+`web/frontend/src/app/components/a2ui/a2-ui-controller.component.ts` for the renderer.
 The Sandbox demo's "top 3 routes" panel is the easiest example to read end-to-end.
 
-### 7. A2A for agent-to-agent communication
+### 6. A2A for agent-to-agent communication
 
 Agents discover each other via cards at `/.well-known/agent-card.json`. The
 gateway fetches them at startup and routes by declared skill.
@@ -181,9 +168,6 @@ deliberate choice or relying on a temporary one.
   bill. Use it whenever you do not specifically need LLM behavior.
 - **Maps API key is optional.** Without `GOOGLE_MAPS_API_KEY` the planner
   falls back to plan-only routes. This is deliberate degradation, not a bug.
-- **`docs/plans/` contains historical implementation plans.** They are not
-  current architecture: read `docs/architecture/` for "how it is" and
-  `docs/plans/` for "how we got there."
 
 ## Code map
 

--- a/.gemini/skills/getting-started/SKILL.md
+++ b/.gemini/skills/getting-started/SKILL.md
@@ -108,8 +108,8 @@ The Planner works without a Maps key but produces better routes with one.
 1. Enable APIs:
    ```bash
    gcloud services enable apikeys.googleapis.com \
-     agentregistry.googleapis.com mapstools.googleapis.com \
-     places.googleapis.com weather.googleapis.com
+     agentregistry.googleapis.com cloudapiregistry.googleapis.com \
+     mapstools.googleapis.com places.googleapis.com weather.googleapis.com
    ```
 
 2. Create a key at https://console.cloud.google.com/apis/credentials.

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,10 @@ __pycache__/
 # docs/plans/2026-04-18-bug-b-h1-parallel-tool-revert-design.md.
 .harness-runs/
 
+# Local planning and design docs (working artifacts only; not part of the
+# repo's tracked architecture documentation).
+docs/plans/
+
 # Terraform
 infra/.terraform/
 infra/.terraform.lock.hcl


### PR DESCRIPTION
## What changed

The four top-level dev-workflow skills (`exploring-the-codebase`,
`getting-started`, `contributing`, `deploying`), mirrored across
`.claude/skills/` and `.gemini/skills/`, had drifted from the repo:
dead file paths, a pattern section describing code that no longer
exists, an incomplete `gcloud services enable` list that contradicted
the surrounding instructions, an out-of-date `pytest` invocation, and a
Cloud Run service name that does not exist.

This PR is two passes on the eight files:

1. **Surgical correctness.** Replace verified-dead references with
   verified successors, or remove the surrounding section when no
   successor exists.
2. **Polish.** Run humanizer, the enforce-mermaid policy, and the
   de-claude subagent over the corrected files. Convert the ASCII
   directory tree to a prose list (no spatial plain-text layouts),
   trim prose em-dashes, drop a "serves as" copula avoidance, and
   remove sycophantic closers.

Mirror parity (`diff -rq .claude/skills .gemini/skills` returns empty)
holds at every commit. Squash-merge produces one combined commit on
`main`.

## Per-skill highlights

**exploring-the-codebase**

- `agents/simulator/simulation/engine.py` did not exist. The engine is
  `race_engine = LoopAgent(...)` defined inline in
  `agents/simulator/agent.py`.
- `web/frontend/.../a2-ui-controller.ts` is actually `.component.ts`
  (Angular component pattern).
- `internal/ecs/` and `internal/sim/` do not exist. The entire "ECS for
  simulation state" pattern section was fictional and was removed.
- The "deterministic runner baseline" row pointed at the LLM runner
  first. Renamed to "How the runner pair is structured" and labeled
  each agent's role explicitly.
- Added `docs/plans/` to `.gitignore` (working artifacts, not tracked
  architecture docs) and removed the stale bullet that treated the
  directory as a curated archive.
- ASCII tree code map replaced with a prose list.

**getting-started**

- The `gcloud services enable` block was missing
  `cloudapiregistry.googleapis.com`, even though the next step told
  users to restrict the key to "Cloud API Registry API". Added; the
  enable list now matches what `infra/modules/project-apis/variables.tf`
  enables in production.

**contributing**

- `npx pyright agents/` is `npx --yes pyright@latest agents/`.
- `lint-configs` validates YAML and JSON only. The "Dockerfile
  validation" claim was wrong.
- `make test-py` is `uv run pytest agents/ -x -q -m "not slow and not
  integration"` (added the integration exclusion and the `uv run`
  prefix).

**deploying**

- The `terraform.tfvars` template was missing `enable_runner_cloudrun`
  and `alert_email`. Added.
- Phase 5 step 3 referenced an `admin-dash` Cloud Run service. The
  service is `admin`; `admin-dash` is the UI it serves. The same file's
  service list on the previous page already had it right.
- Annotated `runner-cloudrun` in the verification list as conditional
  on `enable_runner_cloudrun = true`, so operators don't think the
  deploy failed when the service is absent by design.

## Test plan

- `diff -rq .claude/skills .gemini/skills` returns empty after every
  commit.
- Every file path, Make target, gcloud API name, and Cloud Run service
  name in the four skills resolves to a real thing in the repo, or has
  been removed. Verified with `gcloud services list --available`,
  `grep` against `Makefile`, `cloudbuild-bootstrap.yaml`, and
  `infra/modules/`.
- `make lint-go` and `make lint-py` pass clean. `make lint-pyright` and
  `make lint-configs` also fail on `main` for unrelated reasons
  (pyright lacks a venv config; some `tsconfig*.json` files contain
  JSON5 comments that `check-json` rejects). Neither is touched by
  this PR.
- A subagent code review was run on the branch before this PR was
  opened. Three findings (one Critical, two Important) were applied in
  the final commit on the branch.

## Out of scope

- `.claude/skills/` and `.gemini/skills/` are byte-identical duplicates
  with no sync mechanism in the repo. This PR keeps them in sync by
  editing both copies in every commit, but does not automate it. Worth
  a follow-up to either pick one canonical location and symlink, or add
  a `make sync-skills` target.
- Agent-bundled skills under `agents/*/skills/` were not audited.
