### PR TITLE
🔧 chore(pre-commit): exclude tsconfig*.json from check-json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,9 @@ repos:
     hooks:
       - id: check-yaml
       - id: check-json
+        # tsconfig*.json files are JSONC (JSON with comments); check-json can't parse them.
+        # https://github.com/pre-commit/pre-commit-hooks/issues/395
+        exclude: '(^|/)tsconfig(\.[^/]+)?\.json$'
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: local


### PR DESCRIPTION
## Summary

`pre-commit run --all-files` fails out of the box on a fresh checkout because the `check-json` hook (from `pre-commit/pre-commit-hooks`) cannot parse the three Angular-generated tsconfig files in `web/frontend/`:

```
web/frontend/tsconfig.app.json: Failed to json decode (Expecting value: line 1 column 1 (char 0))
web/frontend/tsconfig.spec.json: Failed to json decode (Expecting value: line 1 column 1 (char 0))
web/frontend/tsconfig.json: Failed to json decode (Expecting value: line 1 column 1 (char 0))
```

These files begin with `/* ... */` comments — JSONC, the standard format for `tsconfig.json` and what `ng new` emits. `check-json` is strict JSON only and the upstream maintainers' [recommended workaround](https://github.com/pre-commit/pre-commit-hooks/issues/395) is to exclude such files from the hook.

## Change

Add a one-line `exclude:` regex to the `check-json` hook covering any `tsconfig*.json` path. The TypeScript compiler validates these files at build time, so we lose nothing by skipping them in pre-commit.

```yaml
- id: check-json
  # tsconfig*.json files are JSONC (JSON with comments); check-json can't parse them.
  # https://github.com/pre-commit/pre-commit-hooks/issues/395
  exclude: '(^|/)tsconfig(\.[^/]+)?\.json$'
```

The regex is anchored to a path boundary (`^` or `/`), so unrelated names like `mytsconfig.json` would not be excluded, and it requires a literal `.json` extension (not `tsconfig.foojson`).

## Verification

```
$ pre-commit run check-json --all-files
check json...............................................................Passed
```

All five `tsconfig*.json` files in the repo (`web/frontend/{tsconfig,tsconfig.app,tsconfig.spec}.json`, `web/admin-dash/tsconfig.json`, `web/tester/tsconfig.json`) are correctly skipped; other JSON files (e.g. `web/frontend/package.json`, agent seed files) are still validated.

## Out of scope

`pre-commit run --all-files` also surfaces unrelated pre-existing failures (`addlicense` adds headers to one file; `end-of-file-fixer` and `trailing-whitespace` want to touch ~80 files). Those should be addressed in separate PRs.