### PR TITLE
🔧 ci: enforce `make lint` end-to-end and fix pyright venv discovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,17 @@ jobs:
       - name: Install Python deps
         run: uv sync --frozen
 
-      - name: Lint Python
-        run: uv run ruff check agents/
+      - name: Install lint tools
+        # golangci-lint is pinned; install pattern mirrors `addlicense` above.
+        # pre-commit is required by the `lint-configs` Makefile target.
+        run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+          uv tool install pre-commit
+
+      - name: Lint
+        # Single source of truth: `make lint` runs Go, Python (ruff), pyright,
+        # and config (yaml/json) linters. Matches what contributors run locally.
+        run: make lint
 
       - name: Test Python
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,13 @@ omit = ["agents/tests/*", "agents/**/test_*"]
 fail_under = 60
 show_missing = true
 
+[tool.pyright]
+# Point pyright at the uv-managed virtualenv so `npx pyright agents/`
+# resolves project dependencies without needing per-invocation flags.
+# `uv sync` creates ./.venv at the repo root.
+venvPath = "."
+venv = ".venv"
+
 [tool.ruff]
 target-version = "py313"
 line-length = 120


### PR DESCRIPTION
## Summary

- Configure pyright to discover `.venv` via `[tool.pyright]` in `pyproject.toml`, fixing 433 phantom "Import could not be resolved" errors from `make lint-pyright`.
- Replace the bespoke `Lint Python` step in CI with a single `Lint` step that runs `make lint`, so contributors and CI exercise the same checks (Go, Python/ruff, pyright, configs).

## Why

CI previously ran only `uv run ruff check agents/`, leaving `lint-go`, `lint-pyright`, and `lint-configs` unenforced. That gap allowed:

- An invalid `pre-commit` `check-json` config to land against JSONC `tsconfig*.json` files (fixed in #47), and
- Pyright misconfiguration to persist in `make lint-pyright` undetected.

Wiring `make lint` directly into CI gives one canonical lint surface and would have caught both issues automatically.

## Verification

- `make lint` exits 0 locally on this branch (Go ✅, ruff ✅, pyright ✅, check-yaml ✅, check-json ✅).
- CI on this PR will be the first run that exercises every lint sub-target.

## Notes

- `golangci-lint` is pinned to `v1.64.8` (matches local toolchain; mirrors the `addlicense` install pattern already on line 48).
- `pre-commit` is installed via `uv tool install` so `lint-configs` works in CI.
- No Makefile change required — the pyright fix is entirely in `pyproject.toml`.