### PR TITLE
🔧 chore(oss): remove dead OSS-sync references and fix deploy_test resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,9 +80,6 @@ __pycache__/
 
 # Local IDE/agent scratch
 .vscode/
-# Track the OSS template's .gemini/config.yaml (overlaid into the public repo
-# during `make oss-sync`; needs to be committed even though .gemini/ is ignored).
-!scripts/oss/templates/.gemini/
 
 # Diagnostic harness outputs (per-trial JSON dumps from
 # scripts/diagnostics/demo1_harness.py); see

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 -include .env
 export
 
-.PHONY: init check-prereqs infra-init infra-plan infra-apply infra-destroy infra-output deploy deploy-local help test lint lint-go lint-py lint-pyright lint-configs fmt build proto ensure-venv coverage coverage-go coverage-py test-unit-go test-integration-go test-py-integration test-web verify perf-test perf-diagnostic eval-stress test-e2e-simulation docker-build-all docker-build-go docker-build-py eval oss-harden start stop restart
+.PHONY: init check-prereqs infra-init infra-plan infra-apply infra-destroy infra-output deploy deploy-local help test lint lint-go lint-py lint-pyright lint-configs fmt build proto ensure-venv coverage coverage-go coverage-py test-unit-go test-integration-go test-py-integration test-web verify perf-test perf-diagnostic eval-stress test-e2e-simulation docker-build-all docker-build-go docker-build-py eval start stop restart
 
 .DEFAULT_GOAL := help
 
@@ -46,7 +46,7 @@ build: proto ## Build all Go binaries
 	go build ./...
 
 # --- Test ---
-test: test-go test-py test-web test-deploy-sh test-oss-sync ## Run all tests (Go + Python + Web + deploy.sh + OSS sync smoke)
+test: test-go test-py test-web test-deploy-sh ## Run all tests (Go + Python + Web + deploy.sh)
 
 test-go:
 	go test ./... -count=1
@@ -64,10 +64,7 @@ test-web:
 	@echo "✅ All web UI tests passed."
 
 test-deploy-sh: ## Run scripts/deploy.sh unit tests (region parity + argv shape)
-	@bash scripts/oss/templates/scripts/deploy_test.sh
-
-test-oss-sync: ## Run scripts/oss/sync.sh smoke tests (Phase 5 artifact paths + perms)
-	@bash scripts/oss/sync_smoke_test.sh
+	@bash scripts/deploy_test.sh
 
 # --- Agent Evaluations (requires Gemini API) ---
 eval: ## Run agent evaluations (requires Gemini API)
@@ -170,20 +167,6 @@ docker-build-all: docker-build-gateway docker-build-admin docker-build-tester do
 docker-build-go: docker-build-gateway docker-build-admin docker-build-tester docker-build-frontend
 
 docker-build-py: docker-build-runner_autopilot docker-build-runner_cloudrun docker-build-dash
-
-
-oss-harden: ## Apply security hardening to the OSS repo (Actions, rulesets, Dependabot)
-	@bash scripts/oss/configure_repo.sh $(OSS_REPO)
-
-# resolves the target the same way the sync script does.
-	if [ -f .git ]; then \
-		_GIT_COMMON=$$(git rev-parse --git-common-dir); \
-		_MAIN_REPO=$$(cd "$$_GIT_COMMON/.." && pwd); \
-		echo "$$(cd "$$_MAIN_REPO/.." && pwd)/race-condition"; \
-	else \
-		echo "$$(cd .. && pwd)/race-condition"; \
-	fi')
-
 
 
 # --- Developer Experience ---

--- a/infra/modules/cloud-run-iam/main.tf
+++ b/infra/modules/cloud-run-iam/main.tf
@@ -15,7 +15,7 @@
 # Service-level IAM bindings for Cloud Run services.
 #
 # Replaces the `gcloud run services add-iam-policy-binding` shim that
-# was previously in scripts/oss/templates/scripts/deploy/deploy.py.
+# was previously in scripts/deploy/deploy.py.
 #
 # Defense in depth: the iam module ALSO grants project-level
 # roles/run.invoker to the AE SA. Project-level grants have shown

--- a/infra/modules/cloud-run-services/main.tf
+++ b/infra/modules/cloud-run-services/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Common env vars threaded into every Race Condition Cloud Run service.
-# Mirrors scripts/oss/templates/scripts/deploy/deploy.py:build_env_vars()
+# Mirrors scripts/deploy/deploy.py:build_env_vars()
 # (the legacy gcloud-based deployer). Cross-service URLs (ADMIN_URL,
 # DASH_URL, ...) are deliberately omitted: they cause TF dependency
 # cycles between services. The Phase 4 Cloud Build orchestrator wires

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -73,15 +73,6 @@ scripts/
 | `spark_alloydb_processor.py` | `README.md` | PySpark + Document AI pipeline for ingesting PDF regulations into AlloyDB |
 | `generate_local_seeds.py` | -- | Generates `seed_local.sql` with pre-computed embeddings for local Postgres |
 
-## `oss/` -- Open-Source Release
-
-| File | Integration | Description |
-|:---|:---|:---|
-| `sync.sh` | `Makefile` (`oss-sync`) | Syncs backend + frontend to the `race-condition` OSS repo with Go module rewrite, port remapping, and sanitization |
-| `excludes.txt` | `sync.sh` | rsync exclude patterns for backend sync |
-| `excludes-frontend.txt` | `sync.sh` | rsync exclude patterns for frontend sync |
-| `templates/` | `sync.sh` | OSS overlay files (LICENSE, CONTRIBUTING, CI workflows, skills) |
-
 ## `tests/` -- Script Tests
 
 | Test File | Tests For |

--- a/scripts/deploy_test.sh
+++ b/scripts/deploy_test.sh
@@ -24,36 +24,22 @@ DEPLOY_SH="${SCRIPT_DIR}/deploy.sh"
 PASS=0
 FAIL=0
 
-# Resolve variables.tf for both layouts (monorepo + synced OSS repo).
-# Override with DEPLOY_SH_TF_VARS_FILE if auto-detect ever drifts.
+# Resolve <repo>/infra/variables.tf via git. Works for both the main
+# checkout and any worktree, since `git rev-parse --show-toplevel`
+# returns the worktree's own root. Override with DEPLOY_SH_TF_VARS_FILE
+# if auto-detect ever drifts.
 resolve_tf_vars_file() {
   if [[ -n "${DEPLOY_SH_TF_VARS_FILE:-}" ]]; then
     echo "$DEPLOY_SH_TF_VARS_FILE"
     return
   fi
 
-  # Git-aware resolution for the monorepo / backend worktree layout.
-  local git_root project_root
-  if git_root=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null); then
-    if [[ "$git_root" == */.worktrees/* ]]; then
-      # Worktree: .../backend/.worktrees/topic/<branch>; project root is 4 up.
-      project_root="$(cd "$git_root/../../../.." && pwd)"
-    else
-      # Main checkout: .../backend; project root is 1 up.
-      project_root="$(cd "$git_root/.." && pwd)"
-    fi
-    local candidates=(
-      "$project_root/code-infra/.worktrees/topic/oss-deploy/projects/oss/variables.tf"
-      "$project_root/code-infra/projects/oss/variables.tf"
-    )
-    for c in "${candidates[@]}"; do
-      [[ -f "$c" ]] && { echo "$c"; return; }
-    done
-  fi
+  local repo_root
+  repo_root=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null) \
+    || repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-  # OSS-synced layout fallback (scripts/deploy_test.sh -> ../infra/variables.tf).
-  if [[ -f "${SCRIPT_DIR}/../../infra/variables.tf" ]]; then
-    echo "${SCRIPT_DIR}/../../infra/variables.tf"
+  if [[ -f "$repo_root/infra/variables.tf" ]]; then
+    echo "$repo_root/infra/variables.tf"
     return
   fi
 


### PR DESCRIPTION
## Summary

- Remove references to the OSS-sync workflow that this repo used before becoming the source of truth.
- Fix `make test`, which failed because two Makefile targets (`test-deploy-sh`, `test-oss-sync`) pointed at scripts that no longer exist.
- Fix `scripts/deploy_test.sh`'s `resolve_tf_vars_file` so `test_region_allowlist_matches_terraform` actually runs. It was silently SKIPping due to a bad fallback path.

## Why

After #51, `make lint` runs in CI but `make test` still does not. Locally, `make test` was failing on `test-deploy-sh` (`scripts/oss/templates/scripts/deploy_test.sh: No such file or directory`) and `test-oss-sync` (same missing directory). Investigation found other lingering references to the dead `scripts/oss/` tree in Makefile targets, `.gitignore`, README documentation, and Terraform comments, plus a path-resolver bug in `scripts/deploy_test.sh` that caused one of its six subtests to silently SKIP.

## Changes

### Commit 1: `🔧 chore(oss): remove dead OSS-sync references`

- Makefile: rewire `test-deploy-sh` to `scripts/deploy_test.sh`; drop `test-oss-sync`, `oss-harden`, an orphaned recipe fragment, and the `oss-harden` entry in `.PHONY`. Update `test`'s help text.
- .gitignore: drop the `!scripts/oss/templates/.gemini/` negation and its `oss-sync` comment.
- scripts/README.md: drop the `## oss/` section.
- infra/modules/cloud-run-{services,iam}/main.tf: update two stale comment paths from `scripts/oss/templates/scripts/deploy/deploy.py` to `scripts/deploy/deploy.py`.

### Commit 2: `🐛 fix(deploy_test): resolve variables.tf via repo root`

`resolve_tf_vars_file` was hard-coded for the multi-repo layout: it tried two `code-infra/...` candidates (gone), then fell through to `${SCRIPT_DIR}/../../infra/variables.tf` whose two-dotdot prefix resolved outside the repo. (The comment said one dotdot; the code had two.)

Replaced with a single `git rev-parse --show-toplevel` lookup of `<repo>/infra/variables.tf`. Works identically from main checkouts and worktrees. `DEPLOY_SH_TF_VARS_FILE` override preserved.

## Verification

- `make test` exits 0; `test-deploy-sh` reports 6 passed, 0 failed (previously 5 passed, 1 SKIP).
- `make lint` green.
- `make help` parses cleanly with no orphaned recipe output.
- `grep -r "scripts/oss\\|oss-sync\\|oss-harden"` finds nothing.

## Out of scope

No active runtime code paths change. The diff touches only the test/build harness and stale documentation comments.