### PR TITLE
🐛 fix(test): isolate secret-path test from host GOOGLE_CLOUD_PROJECT

### DIFF
--- a/agents/planner_with_memory/tests/test_store_alloydb.py
+++ b/agents/planner_with_memory/tests/test_store_alloydb.py
@@ -95,12 +95,14 @@ class TestResolvePassword:
         with patch.dict("os.environ", {"ALLOYDB_PASSWORD": ""}), _patch_sm(client):
             assert mod._resolve_password() == "stale-pw"
 
-    def test_uses_correct_secret_path(self) -> None:
+    def test_uses_correct_secret_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # _SM_PROJECT is captured at import time; setenv would be too late.
+        monkeypatch.setattr(mod, "_SM_PROJECT", "sentinel-project-xyz")
         client = _make_sm_client(response=_make_sm_response(b"pw"))
         with patch.dict("os.environ", {"ALLOYDB_PASSWORD": ""}), _patch_sm(client):
             mod._resolve_password()
         name = client.access_secret_version.call_args.kwargs["name"]
-        assert "test-project" in name
+        assert "sentinel-project-xyz" in name
         assert "am-db-password" in name
 
     def test_strips_whitespace_from_payload(self) -> None:


### PR DESCRIPTION
## Summary

Fixes a test that fails on developer machines whose `.env` sets `GOOGLE_CLOUD_PROJECT` to anything other than `test-project`.

## Problem

`agents/planner_with_memory/tests/test_store_alloydb.py::TestResolvePassword::test_uses_correct_secret_path` asserts `"test-project" in name`. The literal value comes from `agents/conftest.py:25`, which does `os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "test-project")`. Because `setdefault` doesn't overwrite, the Makefile's `-include .env / export` lets a developer's real GCP project win, and the assertion fails:

```
AssertionError: assert 'test-project' in 'projects/goog-caseywest/secrets/am-db-password/versions/latest'
```

CI doesn't see this because `.github/workflows/ci.yml:96` sets `GOOGLE_CLOUD_PROJECT: test-project` explicitly.

## Fix

`monkeypatch.setattr(mod, "_SM_PROJECT", "sentinel-project-xyz")` directly patches the module constant the production code captured at import time. `monkeypatch.setenv` would have been too late since `_SM_PROJECT` is read at module load. Assert against the sentinel rather than the literal "test-project" so the test proves the production code uses `_SM_PROJECT`, instead of passing by coincidence.

Net change: 4 lines.

## Verification

- RED: 1 failed reproduced with `GOOGLE_CLOUD_PROJECT=goog-caseywest` from `.env`.
- GREEN with `.env` loaded: 1 passed for the test, 10 passed for the file, 1520 passed for the full suite.
- GREEN in clean env (`env -i HOME=$HOME PATH=$PATH`): 1 passed.
- `make test` exits 0 (Python 1520, web 36, deploy.sh 6).
- `make lint` green.

## Out of scope (follow-ups)

Code review flagged two larger issues that are out of scope but worth tracking:

1. `agents/conftest.py:25` `setdefault` should be a direct assignment so host env never leaks into agent tests.
2. `agents/planner_with_memory/memory/store_alloydb.py:39-43` captures env at import time. Reading lazily inside `_resolve_password()` would eliminate this class of test brittleness.