### PR TITLE
🐛 fix(test): pin agent test env vars to defeat .env leakage

### DIFF
--- a/agents/conftest.py
+++ b/agents/conftest.py
@@ -21,11 +21,33 @@ Prevents module-level state from leaking between tests.
 # agents/planner_with_memory/__init__.py eagerly imports agent.py, which calls
 # create_session_service() and create_memory_service() at module level.
 # If these are not set, ValueError is raised during collection.
+#
+# Direct assignment (not setdefault) is deliberate: the Makefile loads the
+# developer's .env via `-include .env / export`, so any value exported there
+# would silently win against setdefault and pollute test runs (the original
+# bug behind PR #53). Each entry below documents the import-time consumer
+# that motivates pinning it.
 import os
 
-os.environ.setdefault("GOOGLE_CLOUD_PROJECT", "test-project")
-os.environ.setdefault("GOOGLE_CLOUD_AGENT_ENGINE_ID", "test-agent-engine")
-os.environ.setdefault("ALLOYDB_HOST", "127.0.0.1")
+# Read by agents/utils/env.py, store_alloydb's SM project resolution chain,
+# memory_manager, evaluator/tools.py, simulation_executor, and others.
+os.environ["GOOGLE_CLOUD_PROJECT"] = "test-project"
+os.environ["PROJECT_ID"] = "test-project"
+
+# Read by simulation_executor, memory_manager, runtime, embeddings.
+os.environ["GOOGLE_CLOUD_LOCATION"] = "global"
+
+# Read by runtime.create_session_service / create_memory_service when
+# agents/planner_with_memory/__init__.py imports agent.py at collection.
+os.environ["GOOGLE_CLOUD_AGENT_ENGINE_ID"] = "test-agent-engine"
+
+# Read by store_alloydb._get_dsn(); pin so tests never accidentally point at
+# a real AlloyDB instance from a developer's .env.
+os.environ["ALLOYDB_HOST"] = "127.0.0.1"
+
+# SECRET_MANAGER_PROJECT wins the SM project resolution chain in
+# store_alloydb. Pop it so resolution falls through to GOOGLE_CLOUD_PROJECT.
+os.environ.pop("SECRET_MANAGER_PROJECT", None)
 
 from unittest.mock import patch  # noqa: E402
 

--- a/agents/tests/test_conftest_env_isolation.py
+++ b/agents/tests/test_conftest_env_isolation.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test for PR #53 follow-up: ``agents/conftest.py`` must pin its
+test env vars even when the host shell exports conflicting values via the
+Makefile's ``-include .env / export``.
+
+Spawned in a subprocess to control the inherited environment deterministically.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_conftest_pins_env_against_host_leakage():
+    repo_root = Path(__file__).resolve().parents[2]
+    keys = [
+        "GOOGLE_CLOUD_PROJECT",
+        "PROJECT_ID",
+        "GOOGLE_CLOUD_LOCATION",
+        "GOOGLE_CLOUD_AGENT_ENGINE_ID",
+        "ALLOYDB_HOST",
+        "SECRET_MANAGER_PROJECT",
+    ]
+    hostile = {
+        **os.environ,
+        "GOOGLE_CLOUD_PROJECT": "hostile-project",
+        "PROJECT_ID": "hostile-project",
+        "GOOGLE_CLOUD_LOCATION": "hostile-region",
+        "GOOGLE_CLOUD_AGENT_ENGINE_ID": "hostile-engine",
+        "ALLOYDB_HOST": "hostile-host",
+        "SECRET_MANAGER_PROJECT": "hostile-sm-project",
+    }
+    script = (
+        "import os, json, sys, agents.conftest\n"
+        "json.dump({k: os.environ.get(k) for k in sys.argv[1:]}, sys.stdout)\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script, *keys],
+        env=hostile,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+
+    assert data["GOOGLE_CLOUD_PROJECT"] == "test-project"
+    assert data["PROJECT_ID"] == "test-project"
+    assert data["GOOGLE_CLOUD_LOCATION"] == "global"
+    assert data["GOOGLE_CLOUD_AGENT_ENGINE_ID"] == "test-agent-engine"
+    assert data["ALLOYDB_HOST"] == "127.0.0.1"
+    assert data["SECRET_MANAGER_PROJECT"] is None


### PR DESCRIPTION
Follow-up to #53. Closes the source of the bug PR #53 patched at the symptom level.

`agents/conftest.py` used `os.environ.setdefault(...)`, so any value the developer's `.env` exported (loaded by the Makefile via `-include .env / export`) silently won. The PR #53 secret-path test broke for exactly this reason.

## Changes

- Switch to direct assignment for `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `GOOGLE_CLOUD_AGENT_ENGINE_ID`, and `ALLOYDB_HOST`.
- Add `PROJECT_ID` to the pin list — sibling of `GOOGLE_CLOUD_PROJECT`, feeds the same resolution chains in `agents/utils/env.py` and `store_alloydb`.
- Pop `SECRET_MANAGER_PROJECT` so the `store_alloydb` SM chain falls through to the pinned `GOOGLE_CLOUD_PROJECT`.
- Add `agents/tests/test_conftest_env_isolation.py`: spawns a subprocess with hostile env values and asserts conftest pins them. Confirmed RED on the old `setdefault` form; passes after the fix.

## Verified

- `make test`: Python 1521 passed, web 36 passed, deploy_test 6 passed. Run with the developer's polluted `.env` loaded (`GOOGLE_CLOUD_PROJECT=goog-caseywest`).
- `make lint`: clean across golangci-lint, ruff, pyright, and pre-commit.