### PR TITLE
♻️ refactor(alloydb): read SM_PROJECT lazily so tests can use monkeypatch.setenv

### DIFF
--- a/agents/planner_with_memory/memory/store_alloydb.py
+++ b/agents/planner_with_memory/memory/store_alloydb.py
@@ -36,16 +36,24 @@ from agents.planner_with_memory.memory.schemas import PlannedRoute, SimulationRe
 logger = logging.getLogger(__name__)
 
 _SECRET_TTL_SECONDS = 1800  # 30 minutes
-_SM_PROJECT = (
-    os.environ.get("SECRET_MANAGER_PROJECT")
-    or os.environ.get("GOOGLE_CLOUD_PROJECT")
-    or os.environ.get("PROJECT_ID", "")
-)
 _SM_SECRET = "am-db-password"
 
 # (password, monotonic_timestamp) -- single tuple for atomic cache updates.
 _cached: tuple[str, float] | None = None
 _sm_client: secretmanager.SecretManagerServiceClient | None = None
+
+
+def _resolve_sm_project() -> str:
+    """Return the Secret Manager project, read lazily from the environment.
+
+    Read at call time (not import) so tests can override via
+    ``monkeypatch.setenv`` and operators can rotate without a process restart.
+    """
+    return (
+        os.environ.get("SECRET_MANAGER_PROJECT")
+        or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        or os.environ.get("PROJECT_ID", "")
+    )
 
 
 def _get_sm_client() -> secretmanager.SecretManagerServiceClient:
@@ -68,7 +76,7 @@ def _resolve_password() -> str:
     if _cached is not None and (now - _cached[1]) < _SECRET_TTL_SECONDS:
         return _cached[0]
 
-    secret_name = f"projects/{_SM_PROJECT}/secrets/{_SM_SECRET}/versions/latest"
+    secret_name = f"projects/{_resolve_sm_project()}/secrets/{_SM_SECRET}/versions/latest"
     try:
         response = _get_sm_client().access_secret_version(name=secret_name)
         password = response.payload.data.decode("utf-8").strip()

--- a/agents/planner_with_memory/tests/test_store_alloydb.py
+++ b/agents/planner_with_memory/tests/test_store_alloydb.py
@@ -96,8 +96,7 @@ class TestResolvePassword:
             assert mod._resolve_password() == "stale-pw"
 
     def test_uses_correct_secret_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # _SM_PROJECT is captured at import time; setenv would be too late.
-        monkeypatch.setattr(mod, "_SM_PROJECT", "sentinel-project-xyz")
+        monkeypatch.setenv("SECRET_MANAGER_PROJECT", "sentinel-project-xyz")
         client = _make_sm_client(response=_make_sm_response(b"pw"))
         with patch.dict("os.environ", {"ALLOYDB_PASSWORD": ""}), _patch_sm(client):
             mod._resolve_password()
@@ -137,3 +136,29 @@ class TestGetDsn:
             pytest.raises(ValueError, match="ALLOYDB_HOST"),
         ):
             mod._get_dsn()
+
+
+class TestResolveSmProject:
+    def test_prefers_secret_manager_project(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SECRET_MANAGER_PROJECT", "sm-pid")
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "gcp-pid")
+        monkeypatch.setenv("PROJECT_ID", "fallback-pid")
+        assert mod._resolve_sm_project() == "sm-pid"
+
+    def test_falls_back_to_google_cloud_project(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SECRET_MANAGER_PROJECT", raising=False)
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "gcp-pid")
+        monkeypatch.setenv("PROJECT_ID", "fallback-pid")
+        assert mod._resolve_sm_project() == "gcp-pid"
+
+    def test_falls_back_to_project_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SECRET_MANAGER_PROJECT", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.setenv("PROJECT_ID", "fallback-pid")
+        assert mod._resolve_sm_project() == "fallback-pid"
+
+    def test_returns_empty_when_all_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SECRET_MANAGER_PROJECT", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("PROJECT_ID", raising=False)
+        assert mod._resolve_sm_project() == ""


### PR DESCRIPTION
Follow-up to #53 (paired with #54). Removes the import-time capture of `_SM_PROJECT` so tests can use `monkeypatch.setenv` and operators can rotate `SECRET_MANAGER_PROJECT` without a process restart.

## Changes

- Extract `_resolve_sm_project()` and call it from `_resolve_password()`.
- Revert PR #53's `monkeypatch.setattr(mod, "_SM_PROJECT", ...)` to `monkeypatch.setenv("SECRET_MANAGER_PROJECT", ...)`.
- Add four unit tests for the precedence chain: `SECRET_MANAGER_PROJECT > GOOGLE_CLOUD_PROJECT > PROJECT_ID > ""`.

## Performance

The hot path adds 1-3 `os.environ.get` calls per AlloyDB connection (microseconds). The TTL cache around the actual Secret Manager response is unchanged.

## Verified

- `make test`: Python 1525 passed (1521 baseline + 4 new), web 36 passed, deploy_test 6 passed. Run with the developer's polluted `.env` loaded.
- `make lint`: clean across golangci-lint, ruff, pyright, and pre-commit.
- The reverted `test_uses_correct_secret_path` was confirmed RED before the refactor and GREEN after.