### PR TITLE
📝 docs: bump Google ADK badge to 1.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Python](https://img.shields.io/badge/Python-3.13+-3776AB?logo=python&logoColor=white)
 ![Node.js](https://img.shields.io/badge/Node.js-24+-339933?logo=nodedotjs&logoColor=white)
 ![Angular](https://img.shields.io/badge/Angular-21-DD0031?logo=angular&logoColor=white)
-![Google ADK](https://img.shields.io/badge/Google_ADK-1.30-4285F4?logo=google&logoColor=white)
+![Google ADK](https://img.shields.io/badge/Google_ADK-1.31-4285F4?logo=google&logoColor=white)
 ![Google Cloud](https://img.shields.io/badge/Google_Cloud-4285F4?logo=googlecloud&logoColor=white)
 
 [![Open in Cloud Shell](assets/cloud_shell_button.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/race-condition.git&cloudshell_tutorial=tutorial.md)


### PR DESCRIPTION
## Summary

- README badge for Google ADK was still showing `1.30` after #67 bumped `google-adk[extensions,eval]` to `1.31.1` in `pyproject.toml`.
- One-line update to track the new minor version (matches the existing minor-only badge convention shared with the Angular badge).

## Verification

- CI for #67 (the ADK bump) passed on `main` at sha `2842d00` — full pyright + Go + Python + web suites green.
- Local `make test-py` against ADK 1.31.1: **1525 passed, 2 skipped** in 3:32. No new warnings introduced by the upgrade.

🤖 Generated by [opencode](https://opencode.ai)