### PR TITLE
🔧 chore(deps): ignore a2a-sdk major updates until ADK supports them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,14 @@ updates:
     groups:
       python-minor-patch:
         update-types: [minor, patch]
+    ignore:
+      # google-adk pins a2a-sdk<0.4.0 (verified in 1.31.1 and 2.0.0b1).
+      # Bumping a2a-sdk to 1.x breaks ADK's deep imports of TransportProtocol,
+      # TextPart, etc. The migration code itself is straightforward (see the
+      # closed PR #68); revisit when ADK ships a release that supports
+      # a2a-sdk 1.x.
+      - dependency-name: a2a-sdk
+        update-types: [version-update:semver-major]
 
   # Frontend (Angular)
   - package-ecosystem: npm


### PR DESCRIPTION
## Summary

google-adk 1.31.1 (latest stable) and 2.0.0b1 (latest beta) both pin
\`a2a-sdk<0.4.0\` in their \`[a2a]\` extra and import v0.3-only symbols
(\`TransportProtocol\`, \`TextPart\`, \`TaskStatusUpdateEvent\`, …) at module
load time, regardless of whether the extra is installed.

Accepting Dependabot's proposed bump to a2a-sdk 1.x (#68) makes the project
unimportable. This adds an \`ignore\` rule for a2a-sdk major version bumps
until ADK ships a release that supports a2a-sdk 1.x.

## Context

I prototyped the full migration locally to confirm the upstream blocker:
- All 62 pyright errors in \`agents/\` resolve cleanly with the v1.0 API
- Tests still can't run because \`google.adk.integrations.agent_registry\`
  fails at import time:

\`\`\`
ImportError: cannot import name 'TransportProtocol' from 'a2a.types'
\`\`\`

The migration code (helpers + per-file refactors) is preserved on the
\`dependabot/uv/a2a-sdk-1.0.2\` branch locally for the day ADK catches up.

## What this changes

- \`.github/dependabot.yml\`: adds an \`ignore\` entry under the \`uv\`
  ecosystem block for \`a2a-sdk\` with \`update-types: [version-update:semver-major]\`.

🤖 Generated by [opencode](https://opencode.ai)