### PR TITLE
⬆️ build(deps): bump marked from 17 to 18 in /web/tester

### DIFF
--- a/web/tester/package-lock.json
+++ b/web/tester/package-lock.json
@@ -11,7 +11,7 @@
         "dompurify": "^3.4.11",
         "lodash-es": "^4.18.1",
         "luxon": "^3.7.2",
-        "marked": "^17.0.3",
+        "marked": "^18.0.7",
         "protobufjs": "^8.6.6"
       },
       "devDependencies": {
@@ -2317,9 +2317,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
-      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
+      "version": "18.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
+      "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"

--- a/web/tester/package.json
+++ b/web/tester/package.json
@@ -15,7 +15,7 @@
     "dompurify": "^3.4.11",
     "lodash-es": "^4.18.1",
     "luxon": "^3.7.2",
-    "marked": "^17.0.3",
+    "marked": "^18.0.7",
     "protobufjs": "^8.6.6"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Bumps `marked` from 17 to 18 in `web/tester`, replacing #77 (which conflicted with the lockfile refresh in #198 and has been rebuilt on top of it).

Unlike everything in #198, this is **not** a drift correction. `marked` 18 sits outside the declared `^17.0.3` range, so the spec in `package.json` widens to `^18.0.7`. That makes it a deliberate dependency decision rather than a lockfile refresh, which is why it is split out into its own PR.

## The risk that mattered

`marked` is used in exactly one place — `marked.parse(text)` in `src/a2ui/components/messageBox.ts`:

```ts
const rawHtml = marked.parse(text) as string;
const cleanHtml = DOMPurify.sanitize(rawHtml);
```

That `as string` cast is the hazard. `marked.parse()` has an overload that returns `Promise<string>`, and **a TypeScript cast cannot catch a Promise at runtime**. Had marked 18 changed the default to async, this would compile cleanly, pass type-checking, and then feed `DOMPurify.sanitize()` the string `"[object Promise]"` — rendering every message body as garbage in production, with no build-time signal at all.

So rather than infer safety from a green build, I executed marked 18.0.7 directly against that call shape:

```
typeof: string
isPromise: false
```

Headings, emphasis, inline code and lists all render correctly. `parse()` remains synchronous and the cast is sound.

## Verification

- `npm ci` — clean, **0 vulnerabilities**
- `tsc && vite build` — succeeds
- `vitest` — **36/36 pass**
- runtime probe — `marked.parse()` confirmed synchronous, returns `string`

## Note

This does not close a security advisory; `marked` 17.0.6 had none outstanding. It clears the last stale major in `web/tester` and keeps the workspace current.
