### PR TITLE
👷 ci: add merge_group trigger ahead of enabling the merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,15 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Required before the merge queue can be turned on. A queued pull request is
+  # tested on a temporary `gh-readonly-queue/...` ref, and GitHub reports the
+  # result against the `merge_group` event -- so a required check that does not
+  # listen for this event never reports, and every queued pull request waits
+  # forever. Adding the trigger is inert while the queue is disabled: no
+  # merge_group events are produced, so this changes nothing until the setting
+  # is flipped. That is deliberate -- it has to land first.
+  merge_group:
+    branches: [main]
 
 # Default to least privilege; individual jobs may grant more.
 permissions:


### PR DESCRIPTION
## Why

The merge queue tests each queued PR on a temporary `gh-readonly-queue/...` ref and reports results against the **`merge_group`** event. A required check whose workflow doesn't listen for that event **never reports** — so the queue waits forever and every merge deadlocks.

`build-and-test` is the only required check here, so `ci.yml` is the one that matters.

## This is intentionally inert

With the queue disabled, GitHub emits no `merge_group` events. No new runs, no change to existing `push`/`pull_request` behaviour.

That's the point — **the trigger must be on `main` before the setting is flipped**, never after. This PR is step 1 of 2.

## Concurrency: checked, not assumed

`ci.yml` uses `concurrency: ci-${{ github.ref }}` with `cancel-in-progress: true`, which is exactly the shape that can sabotage a queue if runs share a group.

They don't. A queued run's `github.ref` is the unique per-PR readonly-queue ref (`refs/heads/gh-readonly-queue/main/pr-N-<sha>`), so each lands in its own concurrency group and cannot cancel a sibling. No change needed.

## Not included

**Enabling the queue is a repository setting and is left to you** — I don't change repo settings without explicit approval.

Once this is on `main`, the ordering constraint is satisfied and the queue is safe to turn on.

Verified clean under `zizmor` with online audits enabled, and `make lint-configs` passes.
